### PR TITLE
Update pledge.cc

### DIFF
--- a/pledge.cc
+++ b/pledge.cc
@@ -33,8 +33,12 @@ void Pledge(const FunctionCallbackInfo<Value>& args) {
   } 
 
   const int num = pledge(*String::Utf8Value(isolate, args[0]), NULL);
-  if (num == -1)
-    err(1, "pledge");
+  if (num == -1) {
+    isolate->ThrowException(Exception::TypeError(
+        String::NewFromUtf8(isolate, "Pledge Error",
+            v8::NewStringType::kNormal).ToLocalChecked()));
+    return;
+  }
  
   args.GetReturnValue().Set(num);
 }


### PR DESCRIPTION
Handle pledge error analogous to the other error handling routines. Building node-pledge with the bundled node-gyp from nodejs 18.x results in a compiler error, the cause of which I honestly don't understand. However with this proposed change, node-pledge both builds and works.